### PR TITLE
Fix Graphics component wasting lots of memory

### DIFF
--- a/cocos/2d/components/graphics.ts
+++ b/cocos/2d/components/graphics.ts
@@ -635,13 +635,13 @@ export class Graphics extends UIRenderer {
             const vertexBuffer = gfxDevice.createBuffer(new BufferInfo(
                 BufferUsageBit.VERTEX | BufferUsageBit.TRANSFER_DST,
                 MemoryUsageBit.DEVICE,
-                65535 * stride,
+                8 * stride,
                 stride,
             ));
             const indexBuffer = gfxDevice.createBuffer(new BufferInfo(
                 BufferUsageBit.INDEX | BufferUsageBit.TRANSFER_DST,
                 MemoryUsageBit.DEVICE,
-                65535 * Uint16Array.BYTES_PER_ELEMENT * 2,
+                8 * Uint16Array.BYTES_PER_ELEMENT * 2,
                 Uint16Array.BYTES_PER_ELEMENT,
             ));
 
@@ -673,9 +673,17 @@ export class Graphics extends UIRenderer {
             }
 
             const vb = new Float32Array(renderData.vData.buffer, 0, renderData.vertexStart * componentPerVertex);
+            if (ia.vertexBuffers[0].size < vb.byteLength) {
+                ia.vertexBuffers[0].resize(vb.byteLength);
+            }
             ia.vertexBuffers[0].update(vb);
             ia.vertexCount = renderData.vertexStart;
             const ib = new Uint16Array(renderData.iData.buffer, 0, renderData.indexStart);
+
+            if (ia.indexBuffer!.size < ib.byteLength) {
+                ia.indexBuffer!.resize(ib.byteLength);
+            }
+
             ia.indexBuffer!.update(ib);
             ia.indexCount = renderData.indexStart;
             renderData.lastFilledVertex = renderData.vertexStart;

--- a/cocos/2d/renderer/render-data.ts
+++ b/cocos/2d/renderer/render-data.ts
@@ -575,8 +575,8 @@ export class MeshRenderData extends BaseRenderData {
      */
     public indexRange = 0;
     // only for graphics
-    public lastFilledIndex = 0;
-    public lastFilledVertex = 0;
+    public lastFilledIndex = -1;
+    public lastFilledVertex = -1;
 
     public frame;
 
@@ -695,8 +695,8 @@ export class MeshRenderData extends BaseRenderData {
         this.vertexRange = 0;
         this.indexStart = 0;
         this.indexRange = 0;
-        this.lastFilledIndex = 0;
-        this.lastFilledVertex = 0;
+        this.lastFilledIndex = -1;
+        this.lastFilledVertex = -1;
         this.material = null;
         this.freeIAPool();
     }


### PR DESCRIPTION
Don't have Graphics component always reserver the max vertex and index buffer when in most cases that is way more than is needed. Then just resize as needed.